### PR TITLE
Change Paraglide cookie name

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
     paraglideVitePlugin({
       project: "./project.inlang",
       outdir: "./src/lib/paraglide",
+      cookieName: "LOCALE",
     }),
   ],
 });


### PR DESCRIPTION
Workaround/fix for not being able to change the language after Paraglide changed cookie domain behavior resulting into duplicate cookies and breaking language-switching completely.